### PR TITLE
fix form.elements

### DIFF
--- a/lib/htmlelts.js
+++ b/lib/htmlelts.js
@@ -493,7 +493,7 @@ define({
     enctype: { type: ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"], invalid: "application/x-www-form-urlencoded", missing: "application/x-www-form-urlencoded" },
     encoding: {name: 'enctype', type: ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"], invalid: "application/x-www-form-urlencoded", missing: "application/x-www-form-urlencoded" },
   },
-   props: {
+  props: {
     elements: {
       get: function() {
         var elements = this.querySelectorAll('input, button, fieldset, object, output, select, textarea');

--- a/lib/htmlelts.js
+++ b/lib/htmlelts.js
@@ -493,11 +493,18 @@ define({
     enctype: { type: ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"], invalid: "application/x-www-form-urlencoded", missing: "application/x-www-form-urlencoded" },
     encoding: {name: 'enctype', type: ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"], invalid: "application/x-www-form-urlencoded", missing: "application/x-www-form-urlencoded" },
   },
-  props: {
+   props: {
     elements: {
       get: function() {
-        return this.querySelectorAll('input, button, fieldset, object, output, select, textarea');
-      }
+        var elements = this.querySelectorAll('input, button, fieldset, object, output, select, textarea');
+        for (var i = 0; i < elements.length; i++) {
+          var element = elements[i];
+          elements[element.name] = element;
+        }
+        elements.namedItem = function(name) { return this[name]; };
+        return elements;
+      },
+      configurable: true
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domino-custom-elements",
-  "version": "2.1.4-rc.1",
+  "version": "2.1.4",
   "author": "Paweł Majewski <majo44@gmail.com>",
   "description": "Server-side DOM implementation based on Mozilla's dom.js, with support of custom-elements",
   "homepage": "https://github.com/majo44/domino",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domino-custom-elements",
-  "version": "2.1.3",
+  "version": "2.1.4-rc.1",
   "author": "Paweł Majewski <majo44@gmail.com>",
   "description": "Server-side DOM implementation based on Mozilla's dom.js, with support of custom-elements",
   "homepage": "https://github.com/majo44/domino",

--- a/test/domino.js
+++ b/test/domino.js
@@ -1400,7 +1400,24 @@ exports.incrementalHTMLParser2 = function() {
 };
 
 exports.formElements = function(){
-  var document = domino.createDocument('<body><form><input/><button/><fieldset/><object/><output/><select/><textarea/></form></body>');
+  var document = domino.createDocument('<body><form>' + 
+    '<input name="input"/>'+
+    '<button name="button"></button>'+
+    '<fieldset name="fieldset"></fieldset>'+
+    '<object name="object"></object>'+
+    '<output name="output"></output>'+
+    '<select name="select"></select>'+
+    '<textarea name="textarea"></textarea>'+
+  '</form></body>');
   var form = document.querySelector('form');
-  form.elements.length.should.equal(7);
+  var elements = form.elements;
+  elements.length.should.equal(7);
+  for (var i = 0; i < elements.length; i++) {
+    var element = elements[i];
+    element.should.equal(form.children[i]);
+    elements.item(i).should.equal(element);
+    elements[element.tagName.toLowerCase()].should.equal(element);
+    elements.namedItem(element.name).should.equal(element);
+  }
+
 };

--- a/test/domino.js
+++ b/test/domino.js
@@ -1416,7 +1416,7 @@ exports.formElements = function(){
     var element = elements[i];
     element.should.equal(form.children[i]);
     elements.item(i).should.equal(element);
-    elements[element.tagName.toLowerCase()].should.equal(element);
+    elements[element.name].should.equal(element);
     elements.namedItem(element.name).should.equal(element);
   }
 


### PR DESCRIPTION
it is a named map, i.e.
`form.elements['foo'] => <input name="foo" />`

native form.elements doesn't find inputs inside shadowRoots - so not fixing it in domino